### PR TITLE
Fixed typo in title and corrected URL for MOM6

### DIFF
--- a/gfdl.md
+++ b/gfdl.md
@@ -5,7 +5,7 @@ tagline: GFDL
 logo: NOAA_logo_small.png
 ---
 
-## [Module Ocean Model (MOM6)](http://github.com/CommerceGov/noaa-gfdl-mom6)
+## The [Modular Ocean Model (MOM6)](http://github.com/NOAA-GFDL/MOM6-examples)
 
 MOM6 is the sixth generation of the Modular Ocean Model under
 development by scientists at at NOAA/GFDL, in collaboration with


### PR DESCRIPTION
- The title was a tad incorrect. Fingers probably typed "module" by muscle memory.
- The repository URL was out-of-date. The NOAA-GFDL repositories were relocated from http://github.com/CommerceGov/NOAA-GFDL-% to http://github.com/NOAA-GFDL/% a while back.
